### PR TITLE
Add documentation for all prompting guides

### DIFF
--- a/advanced_topics/hybrid_strategies.md
+++ b/advanced_topics/hybrid_strategies.md
@@ -1,0 +1,10 @@
+### Hybrid Prompting Strategies
+
+**Definition:** Combining multiple prompting techniques to address complex tasks or failure modes.
+
+**Example Approaches:**
+- **Few-shot + Chain-of-Thought:** Demonstrate reasoning steps with examples.
+- **Role + Tree-of-Thought:** Use expert perspective while exploring multiple paths.
+- **Step-back + Self-consistent:** Encourage reflection and generate multiple solutions.
+
+**Tip:** Start with the simplest technique and layer on additional strategies only as needed.

--- a/advanced_topics/integration_techniques.md
+++ b/advanced_topics/integration_techniques.md
@@ -1,0 +1,8 @@
+### Tool Integration Techniques
+
+**Definition:** Connecting the language model with external tools such as APIs, code interpreters, or databases.
+
+**Key Points:**
+- Define clear action formats for tool use (e.g., API calls, code execution).
+- Alternate between reasoning and actions if using the ReAct framework.
+- Include necessary documentation snippets or schema information.

--- a/advanced_topics/multimodal_prompting.md
+++ b/advanced_topics/multimodal_prompting.md
@@ -1,0 +1,9 @@
+### Multimodal Prompting
+
+**Definition:** Adapting prompting techniques to work with inputs and outputs beyond text, such as images or audio.
+
+**Examples:**
+- Chain-of-Thought with images: "Analyze this picture step by step: 1) Identify objects, 2) Describe relationships."
+- Role-based prompts for audio analysis: "As a sound engineer, evaluate this recording."
+
+**Tip:** Clearly specify how the model should reference each modality and what format responses should take.

--- a/advanced_topics/prompt_guardrails.md
+++ b/advanced_topics/prompt_guardrails.md
@@ -1,0 +1,18 @@
+### Prompt Guardrails
+
+**Definition:** Structured instructions that reduce harmful, biased, or non-compliant outputs.
+
+**Techniques:**
+- Output constraints (e.g., "Ensure compliance with financial regulations")
+- Content filtering ("Exclude violent content")
+- Bias mitigation ("Represent diverse perspectives")
+
+**Example Guardrail Prompt:**
+```
+Analyze this financial scenario and recommend investment options.
+Important constraints:
+1. Only suggest regulated investment products
+2. Include risk disclosures for all recommendations
+3. Do not make specific return predictions
+4. Clarify that this is not financial advice
+```

--- a/advanced_topics/rag_prompting.md
+++ b/advanced_topics/rag_prompting.md
@@ -1,0 +1,17 @@
+### Retrieval-Augmented Generation (RAG) Prompting
+
+**Definition:** Combining external knowledge retrieval with generation prompts.
+
+**Prompt Template:**
+```
+Context information:
+[Retrieved document chunks]
+
+Using ONLY the information above, answer the following question.
+Question: [User query]
+```
+
+**Best Practices:**
+- Clearly separate retrieved context from instructions
+- Specify how to handle missing information
+- Consider chunk boundaries when designing prompts

--- a/automation/automatic_prompt_engineering.md
+++ b/automation/automatic_prompt_engineering.md
@@ -1,0 +1,10 @@
+### Automatic Prompt Engineering
+
+**Definition:** Using AI systems to generate or refine prompts programmatically.
+
+**Approach:**
+- Provide examples of successful prompts to a prompt-generation model.
+- Evaluate candidate prompts based on desired metrics.
+- Iterate automatically to discover high-performing prompts.
+
+**Benefit:** Scales experimentation and can uncover novel prompt styles.

--- a/coding_techniques/code_debugging.md
+++ b/coding_techniques/code_debugging.md
@@ -1,0 +1,18 @@
+### Code Debugging Prompts
+
+**Goal:** Help locate and fix errors in existing code.
+
+**Prompt Template:**
+```
+Identify bugs in the following [language] code and suggest fixes:
+[code snippet]
+```
+
+**Example:**
+```
+Identify bugs in this Python function and suggest a corrected version.
+```
+
+**Tips:**
+- Provide context about expected behavior
+- Include any error messages encountered

--- a/coding_techniques/code_explanation.md
+++ b/coding_techniques/code_explanation.md
@@ -1,0 +1,21 @@
+### Code Explanation Prompts
+
+**Goal:** Get the model to describe what a piece of code does, step by step.
+
+**Prompt Template:**
+```
+Explain the following [language] code line by line:
+[code snippet]
+```
+
+**Example:**
+```
+Explain the following Python function line by line:
+
+def add(a, b):
+    return a + b
+```
+
+**Tips:**
+- Provide the code in a fenced block for clarity
+- Mention the target audience (e.g., beginner, advanced)

--- a/coding_techniques/code_generation.md
+++ b/coding_techniques/code_generation.md
@@ -1,0 +1,18 @@
+### Code Generation Prompts
+
+**Goal:** Elicit new code snippets or functions from the model with clear requirements.
+
+**Prompt Template:**
+```
+Write [language] code that [description of task]. Include comments explaining key steps.
+```
+
+**Example:**
+```
+Write Python code that takes a list of numbers and returns the list sorted in descending order. Include comments.
+```
+
+**Tips:**
+- Specify the programming language and version
+- Mention any libraries or frameworks that should be used
+- Provide edge cases or constraints if relevant

--- a/coding_techniques/code_translation.md
+++ b/coding_techniques/code_translation.md
@@ -1,0 +1,21 @@
+### Code Translation Prompts
+
+**Goal:** Convert code from one programming language to another while preserving functionality.
+
+**Prompt Template:**
+```
+Translate the following [source language] code into [target language].
+[code snippet]
+```
+
+**Example:**
+```
+Translate this JavaScript function to Python:
+function square(n) {
+  return n * n;
+}
+```
+
+**Tips:**
+- Indicate any differences in language idioms or libraries
+- Provide the entire code context when possible

--- a/context_techniques/analogy_based.md
+++ b/context_techniques/analogy_based.md
@@ -1,0 +1,30 @@
+### Analogy-based Prompting
+
+**Definition:** Explaining complex or abstract ideas by comparing them to familiar concepts.
+
+**Prompt Template:**
+```
+Explain [complex concept] as if it were [familiar concept or scenario]. Highlight how the elements correspond.
+```
+
+**Example:**
+```
+Explain how the blockchain works as if it were a shared village ledger.
+```
+
+**Best For:**
+- Technical communication to non-experts
+- Educational explanations
+- Making abstract topics more concrete
+
+**Limitations:**
+- Analogy might introduce misconceptions if stretched too far
+- Not ideal when precise terminology is required
+
+**Advantages:**
+- Improves comprehension and retention
+- Connects new information to prior knowledge
+
+**Tips for Success:**
+- Choose analogies familiar to your audience
+- Explicitly map each piece of the analogy to the real concept

--- a/context_techniques/contextual_prompting.md
+++ b/context_techniques/contextual_prompting.md
@@ -1,0 +1,36 @@
+### Contextual Prompting
+
+**Definition:** Providing background information or reference materials so the model can better understand and respond to the request.
+
+**Prompt Template:**
+```
+Context information:
+[background text]
+
+Question: [user query]
+```
+
+**Example:**
+```
+Context information:
+- Product: WidgetPro 2.0
+- Key features: longer battery life, waterproof design
+
+Question: Write a short advertisement for this product.
+```
+
+**Best For:**
+- Situations where the model lacks necessary background knowledge
+- Keeping long-running conversations consistent
+
+**Limitations:**
+- Consumes token budget
+- Context must be relevant and concise
+
+**Advantages:**
+- Reduces ambiguity
+- Ensures output aligns with known facts or constraints
+
+**Tips for Success:**
+- Place critical context near the beginning of the prompt
+- Remove unnecessary details to save tokens

--- a/context_techniques/role_prompting.md
+++ b/context_techniques/role_prompting.md
@@ -1,0 +1,29 @@
+### Role-based Prompting
+
+**Definition:** Instructing the model to respond from the perspective of a specified expert persona.
+
+**Prompt Template:**
+```
+As an experienced [expert role], [task instruction]. Incorporate specialized knowledge typical of this role.
+```
+
+**Example:**
+```
+As an experienced cybersecurity analyst, review the following configuration and identify potential vulnerabilities.
+```
+
+**Best For:**
+- Domain-specific tasks requiring expert knowledge
+- Professional writing with field-specific conventions
+
+**Limitations:**
+- May introduce unwanted bias from the chosen role
+- Not ideal when multiple perspectives are required
+
+**Advantages:**
+- Activates domain-specific knowledge patterns
+- Produces more relevant, specialized answers
+
+**Tips for Success:**
+- Specify the role clearly, including expertise level
+- Provide any relevant context the expert would consider

--- a/context_techniques/system_prompting.md
+++ b/context_techniques/system_prompting.md
@@ -1,0 +1,32 @@
+### System Prompting
+
+**Definition:** Setting overarching instructions that guide the model's behavior across an entire session.
+
+**Prompt Template:**
+```
+You are [desired persona]. Follow these rules:
+1. [Guideline 1]
+2. [Guideline 2]
+...
+```
+
+**Example:**
+```
+You are a concise assistant. Always answer in one short paragraph and avoid speculation.
+```
+
+**Best For:**
+- Establishing tone and style for multi-turn conversations
+- Enforcing global restrictions or safety rules
+
+**Limitations:**
+- Instructions may be forgotten in very long conversations
+- Conflicts between system and user messages can confuse the model
+
+**Advantages:**
+- Provides consistent behavior across requests
+- Useful for customizing voice or style
+
+**Tips for Success:**
+- Keep system prompts short but explicit
+- Restate critical guidelines if the conversation is long

--- a/emerging_techniques/prompt_compression.md
+++ b/emerging_techniques/prompt_compression.md
@@ -1,0 +1,10 @@
+### Prompt Compression
+
+**Definition:** Methods for reducing token usage while maintaining prompt effectiveness.
+
+**Techniques Include:**
+- Instruction distillation (condensing verbose instructions)
+- Example pruning (keeping only the most informative examples)
+- Format optimization (using shorthand symbols)
+
+**Goal:** Fit within context limits without sacrificing clarity or guidance.

--- a/fundamentals/few_shot.md
+++ b/fundamentals/few_shot.md
@@ -1,0 +1,54 @@
+### Few-shot Prompting
+
+**Definition:** Providing 2-5 examples that demonstrate the input-output pattern expected from the model.
+
+**Prompt Template:**
+```
+[Task instruction]
+
+Example 1:
+Input: [input example 1]
+Output: [output example 1]
+
+Example 2:
+Input: [input example 2]
+Output: [output example 2]
+
+Now complete this:
+Input: [actual input]
+Output:
+```
+
+**Example:**
+```
+Classify these reviews as positive, negative, or neutral.
+
+Example 1:
+Input: "This product exceeded my expectations!"
+Output: Positive
+
+Example 2:
+Input: "Worked as advertised but shipping was slow."
+Output: Neutral
+
+Now classify this:
+Input: "Broke after two uses."
+Output:
+```
+
+**Best For:**
+- Establishing consistent output format
+- Clarifying subjective judgment criteria
+- Tasks with clear patterns
+
+**When NOT to Use:**
+- When examples would consume too many tokens
+- When the task is easily understood without examples
+
+**Advantages:**
+- Improves consistency in model responses
+- Reduces need for additional clarification
+
+**Tips for Success:**
+- Use diverse examples covering edge cases
+- Order examples from simple to complex

--- a/fundamentals/model_configuration.md
+++ b/fundamentals/model_configuration.md
@@ -1,0 +1,24 @@
+### Model Configuration
+
+**Purpose:** Setting the appropriate model parameters is critical for controlling output style and quality.
+
+**Key Parameters:**
+- **Temperature:** Controls randomness. Lower values yield more deterministic responses; higher values encourage creativity.
+- **Max Tokens:** Sets the upper limit on response length.
+- **Top-K / Top-P:** Sampling strategies to balance diversity and coherence.
+
+**Example Guidance:**
+```
+Temperature: 0.7
+Max Tokens: 200
+Top-P: 0.9
+```
+
+**Best Practices:**
+- Adjust temperature based on how creative or precise you want the output.
+- Keep max token limits high enough for complete answers but low enough to prevent runaway responses.
+- Experiment with Top-K/Top-P values to fine-tune variability.
+
+**Tips:**
+- Document the configuration used for each prompt during testing.
+- Revisit settings when migrating to a different model family.

--- a/fundamentals/one_shot.md
+++ b/fundamentals/one_shot.md
@@ -1,0 +1,45 @@
+### One-shot Prompting
+
+**Definition:** Providing a single example demonstration to establish the desired pattern.
+
+**Prompt Template:**
+```
+[Task instruction]
+
+Example:
+Input: [example input]
+Output: [example output]
+
+Now complete this:
+Input: [actual input]
+Output:
+```
+
+**Example:**
+```
+Translate the following sentence to French.
+
+Example:
+Input: "Good morning"
+Output: "Bonjour"
+
+Now translate:
+Input: "How are you?"
+Output:
+```
+
+**Best For:**
+- Simple tasks that benefit from one clear demonstration
+- Establishing format when few tokens are available for examples
+
+**Limitations:**
+- Provides less coverage than few-shot examples
+- May not capture edge cases
+
+**Advantages:**
+- Quick to create
+- Clarifies expected structure with minimal token usage
+
+**Tips for Success:**
+- Use a representative example
+- Keep instructions concise

--- a/fundamentals/prompt_engineering_basics.md
+++ b/fundamentals/prompt_engineering_basics.md
@@ -1,0 +1,18 @@
+### Prompt Engineering Basics
+
+**Overview:** Foundational principles that apply to most prompting situations.
+
+**Core Guidelines:**
+- **Clarity First:** Use explicit instructions and avoid ambiguous language.
+- **Provide Context:** Include relevant background so the model understands the scenario.
+- **Specify Format:** Clearly state the desired output structure (bullet points, tables, JSON, etc.).
+- **Iterate and Refine:** Test prompts with varied inputs and adjust based on results.
+- **Track Experiments:** Keep records of prompt versions, model settings, and outcomes for future reference.
+
+**Example Starter Prompt:**
+```
+You are a helpful assistant. Answer the question below in two short paragraphs.
+Question: [insert question]
+```
+
+**Tip:** Start simple, then add constraints or examples if the initial results are off target.

--- a/fundamentals/zero_shot.md
+++ b/fundamentals/zero_shot.md
@@ -1,0 +1,37 @@
+### Zero-shot Prompting
+
+**Definition:** Direct instruction without examples, relying solely on the model's pretrained knowledge.
+
+**Prompt Template:**
+```
+[Task instruction]
+
+[Input]
+```
+
+**Example:**
+```
+Summarize the following article in three concise paragraphs that capture the main points.
+
+[Article text...]
+```
+
+**Best For:**
+- Well-defined tasks within the model's capabilities
+- Simple classification or generation tasks
+- When prompt length must be minimized
+
+**When NOT to Use:**
+- Tasks involving novel formats the model may not understand
+- Complex reasoning problems
+- Requests that require a specific output structure
+
+**Advantages:**
+- Minimal prompt engineering effort
+- Conserves token usage
+- Fast to implement
+
+**Tips for Success:**
+- Be explicit about the desired output format
+- Include clear evaluation criteria
+- Use concise language

--- a/implementation/best_practices.md
+++ b/implementation/best_practices.md
@@ -1,0 +1,7 @@
+### Prompt Engineering Best Practices
+
+1. **Define Success Criteria** – Know what constitutes a good response before you start.
+2. **Match Technique to Task** – Choose zero-shot, few-shot, or advanced strategies based on complexity.
+3. **Provide Necessary Context** – Supply background information or constraints the model should consider.
+4. **Specify Output Format** – Clearly state how the answer should be structured.
+5. **Iterate and Test** – Try multiple prompts, measure results, and refine.

--- a/implementation/documentation_methods.md
+++ b/implementation/documentation_methods.md
@@ -1,0 +1,8 @@
+### Documentation Methods
+
+**Purpose:** Track prompts, versions, and outcomes to build a knowledge base of effective strategies.
+
+**Suggestions:**
+- Maintain a prompt library with descriptions and example outputs.
+- Record model configurations and versions used for each test.
+- Note any issues encountered and how they were resolved.

--- a/implementation/evaluation_framework.md
+++ b/implementation/evaluation_framework.md
@@ -1,0 +1,14 @@
+### Evaluation Framework
+
+**Metrics to Consider:**
+- **Task Completion:** Did the response fulfill the requirements?
+- **Accuracy:** Are factual statements correct?
+- **Reasoning Quality:** Is the logic sound and complete?
+- **Format Adherence:** Does the output match the requested structure?
+- **Efficiency:** Was the response concise yet informative?
+
+**Prompt Iteration Protocol:**
+1. Start with a baseline prompt and test on diverse inputs.
+2. Address failure cases with targeted improvements.
+3. Compare prompt variations and measure effectiveness.
+4. Verify edge cases and add safeguards where needed.

--- a/implementation/json_repair.md
+++ b/implementation/json_repair.md
@@ -1,0 +1,10 @@
+### JSON Repair
+
+**Purpose:** Handle incomplete or malformed JSON outputs from the model.
+
+**Approach:**
+1. Detect whether the JSON can be parsed.
+2. If invalid, attempt common fixes such as closing braces or quoting keys.
+3. Revalidate and, if necessary, ask the model to regenerate just the malformed portion.
+
+**Tip:** Keeping prompts concise and using JSON schema guidance reduces errors in the first place.

--- a/implementation/model_specific_considerations.md
+++ b/implementation/model_specific_considerations.md
@@ -1,0 +1,8 @@
+### Model-specific Considerations
+
+Different language models may require tailored prompting approaches.
+
+**Guidelines:**
+- Check token limits and adjust prompt length accordingly.
+- Review model documentation for supported features and known quirks.
+- Adapt temperature and sampling parameters to match the model's behavior.

--- a/implementation/prompt_debugging_troubleshooting.md
+++ b/implementation/prompt_debugging_troubleshooting.md
@@ -1,0 +1,13 @@
+### Prompt Debugging & Troubleshooting
+
+**Common Issues:**
+- Hallucination or factual errors
+- Ignored instructions
+- Incorrect formatting
+- Unnecessary verbosity
+
+**Fix Strategies:**
+1. Add constraints or more explicit instructions.
+2. Provide or adjust few-shot examples to clarify format.
+3. Break complex requests into smaller steps using Chain-of-Thought.
+4. Specify length requirements to control verbosity.

--- a/implementation/variables_in_prompts.md
+++ b/implementation/variables_in_prompts.md
@@ -1,0 +1,14 @@
+### Variables in Prompts
+
+**Purpose:** Use placeholders or variables to create flexible templates that can be reused with different data.
+
+**Example Template:**
+```
+Generate a short description of {{product_name}} highlighting its main benefit: {{benefit}}.
+```
+
+**Benefits:**
+- Saves time when creating similar prompts at scale
+- Encourages consistent style across different inputs
+
+**Tip:** Clearly delineate variables with markers like `{{variable}}` to avoid confusion.

--- a/output_strategies/json_schema_guidance.md
+++ b/output_strategies/json_schema_guidance.md
@@ -1,0 +1,31 @@
+### JSON Schema Guidance
+
+**Definition:** Using JSON schemas or structural hints to ensure API-friendly responses from the model.
+
+**Prompt Template:**
+```
+Respond in JSON using the following schema:
+{
+  "field1": "string",
+  "field2": "integer",
+  ...
+}
+```
+
+**Example:**
+```
+Provide user information in the schema:
+{
+  "name": "string",
+  "age": number,
+  "email": "string"
+}
+```
+
+**Best For:**
+- Integrations requiring machine-readable output
+- Scenarios where strict structure prevents parsing errors
+
+**Tips:**
+- Validate outputs against the schema during testing
+- Keep schemas simple to reduce model confusion

--- a/output_strategies/output_formats.md
+++ b/output_strategies/output_formats.md
@@ -1,0 +1,21 @@
+### Output Formats
+
+**Definition:** Techniques for directing the model to produce responses in a particular style, such as bullet points, tables, or paragraphs.
+
+**Prompt Template:**
+```
+[Task instruction] Output format: [desired format]
+```
+
+**Example:**
+```
+List three benefits of regular exercise. Output format: bullet list.
+```
+
+**Best For:**
+- Situations where downstream systems expect a certain format
+- Ensuring consistency across multiple responses
+
+**Tips:**
+- State the format requirement explicitly
+- If the format is complex, include a brief example

--- a/output_strategies/structured_output.md
+++ b/output_strategies/structured_output.md
@@ -1,0 +1,25 @@
+### Structured Output
+
+**Definition:** Designing prompts that elicit consistently formatted responses such as bullet lists, tables, or JSON.
+
+**Prompt Template:**
+```
+[Task instruction specifying the desired format]
+```
+
+**Example:**
+```
+Create a table summarizing the planets of our solar system with columns for Name, Diameter, and Number of Moons.
+```
+
+**Best For:**
+- Applications requiring predictable formatting
+- Data extraction or transformation tasks
+
+**Advantages:**
+- Easier downstream processing
+- Helps prevent hallucinated structure
+
+**Tips for Success:**
+- Explicitly describe the desired layout
+- Provide a short example if the format is unusual

--- a/reasoning_frameworks/chain_of_thought.md
+++ b/reasoning_frameworks/chain_of_thought.md
@@ -1,0 +1,35 @@
+### Chain-of-Thought (CoT) Prompting
+
+**Definition:** Guiding the model to reason through a problem step by step before providing the final answer.
+
+**Prompt Template:**
+```
+[Problem statement]
+
+Think through this problem step by step to find the correct answer.
+```
+
+**Example:**
+```
+A store sells notebooks for $3.50 each and pens for $1.25 each. If I bought 4 notebooks and some pens for a total of $21.50, how many pens did I buy?
+
+Think through this problem step by step to find the correct answer.
+```
+
+**Best For:**
+- Mathematical reasoning and logic puzzles
+- Multi-step analytical problems
+
+**When NOT to Use:**
+- Simple factual queries
+- Creative generation tasks
+- When token efficiency is critical
+
+**Advantages:**
+- Improves reasoning accuracy
+- Makes the thought process explicit and auditable
+- Reduces errors in complex calculations
+
+**Tips for Success:**
+- Request labeled steps or numbered reasoning
+- For difficult problems, estimate the number of steps needed

--- a/reasoning_frameworks/react_framework.md
+++ b/reasoning_frameworks/react_framework.md
@@ -1,0 +1,42 @@
+### ReAct Framework
+
+**Definition:** Alternating reasoning and action steps for interactive problem solving, especially when external tools are required.
+
+**Prompt Template:**
+```
+To solve this problem, alternate between:
+1. Thought: Reason about the current state and next step
+2. Action: Perform a specific operation
+3. Observation: Note the result of the action
+4. Repeat until you reach a conclusion
+
+[Problem statement]
+```
+
+**Example:**
+```
+Using the ReAct framework, gather information about recent population trends in Austin, Texas.
+Start with:
+1. Thought: What data sources should I consult?
+2. Action: [Describe search]
+3. Observation: [Describe results]
+4. Thought: How should I refine the search?
+```
+
+**Best For:**
+- Tasks requiring tool use or external information
+- Multi-step information gathering
+- Complex planning scenarios
+
+**Limitations:**
+- Overkill for simple, one-step queries
+- Requires careful separation of thoughts and actions
+
+**Advantages:**
+- Makes reasoning explicit and auditable
+- Breaks complex tasks into manageable steps
+- Combines decision-making with execution
+
+**Tips for Success:**
+- Be specific about allowed actions
+- Include clear stopping conditions

--- a/reasoning_frameworks/self_consistency.md
+++ b/reasoning_frameworks/self_consistency.md
@@ -1,0 +1,34 @@
+### Self-consistent Prompting
+
+**Definition:** Generating multiple independent solutions to a problem and then selecting or synthesizing the most consistent answer.
+
+**Prompt Template:**
+```
+[Problem statement]
+
+Generate 5 independent solutions to this problem without referring to previous solutions. Then identify the most consistent answer and explain why it's likely correct.
+```
+
+**Example:**
+```
+[Problem statement]
+
+Generate 5 different approaches, evaluate them, and present the consensus answer.
+```
+
+**Best For:**
+- High-stakes decisions requiring reliability
+- Problems with potential for error
+- Mathematical or logical questions with verifiable answers
+
+**Limitations:**
+- Not suited for creative tasks with no single right answer
+- Consumes more tokens due to multiple attempts
+
+**Advantages:**
+- Reduces variance and hallucinations
+- Provides a confidence measure through consensus
+
+**Tips for Success:**
+- Request distinct approaches for each attempt
+- Use an odd number of solutions to avoid ties

--- a/reasoning_frameworks/step_back_prompting.md
+++ b/reasoning_frameworks/step_back_prompting.md
@@ -1,0 +1,43 @@
+### Step-back Prompting
+
+**Definition:** Encouraging the model to take a broader perspective or reflect on assumptions before producing a final answer.
+
+**Prompt Template:**
+```
+[Problem statement]
+
+Before answering, take a step back and consider:
+1. What is the broader context of this problem?
+2. What general principles or frameworks apply here?
+3. What assumptions might be incorrect?
+
+After this reflection, solve the problem.
+```
+
+**Example:**
+```
+A startup must decide whether to focus on growing its user base or increasing revenue from existing users.
+
+Before answering, take a step back and consider:
+1. What business principles might apply?
+2. What information is missing?
+3. What assumptions am I making?
+
+After this reflection, provide a recommendation with reasoning.
+```
+
+**Best For:**
+- Strategic decisions and high-level analysis
+- Avoiding tunnel vision on complex issues
+
+**Limitations:**
+- Adds extra steps that may not be necessary for simple tasks
+- Broad reflections consume additional tokens
+
+**Advantages:**
+- Surfaces hidden assumptions
+- Produces more nuanced, thoughtful responses
+
+**Tips for Success:**
+- Include specific reflection questions
+- Allow space for the model to reason before answering

--- a/reasoning_frameworks/tree_of_thoughts.md
+++ b/reasoning_frameworks/tree_of_thoughts.md
@@ -1,0 +1,49 @@
+### Tree-of-Thought (ToT) Prompting
+
+**Definition:** Exploring multiple reasoning paths simultaneously before selecting the most promising one.
+
+**Prompt Template:**
+```
+[Problem statement]
+
+Consider multiple approaches to solving this problem:
+1. First explore approach A...
+2. Then explore approach B...
+3. Finally explore approach C...
+
+For each approach, evaluate its merits and limitations. Then select the most promising approach and use it to solve the problem.
+```
+
+**Example:**
+```
+Solve this logic puzzle: "Five people of different nationalities live in five consecutive houses on a street. Each person has a different profession, drives a different car, and keeps a different pet. Using the clues below, determine who keeps the fish."
+
+[clues...]
+
+Consider three different approaches to solving this puzzle:
+1. First, create a grid and use elimination based on the given clues
+2. Next, try starting with the most restrictive clues and build connections
+3. Finally, try assuming each person has the fish and evaluate if it leads to contradictions
+
+For each approach, work through the initial steps, evaluate its effectiveness, then choose the best approach to solve the puzzle completely.
+```
+
+**Best For:**
+- Problems with multiple possible solution paths
+- Scenarios requiring comparison of different approaches
+- Complex decision-making with trade-offs
+
+**Limitations:**
+- Simple problems with obvious solution methods
+- When limited by token context window
+- Time-sensitive applications needing quick responses
+
+**Advantages:**
+- Prevents getting stuck in reasoning dead-ends
+- Often finds more optimal solutions
+- Models human expert problem-solving more closely
+
+**Tips for Success:**
+- Explicitly define how to evaluate each approach
+- Ensure branches are distinct and meaningfully different
+- Request explicit comparison of pros/cons for each approach

--- a/use_case_applications/code_generation.md
+++ b/use_case_applications/code_generation.md
@@ -1,0 +1,13 @@
+### Code Generation Use Case
+
+**Recommended Techniques:** Chain-of-Thought combined with Step-back Prompting for robust solutions.
+
+**Example Prompt:**
+```
+I need to write a function that identifies potential duplicate customer records in a database.
+Before coding, take a step back and consider:
+1. What defines a "potential duplicate"?
+2. What edge cases should be handled?
+3. What performance considerations matter for 100k+ records?
+Then, think through your solution step by step before providing code.
+```

--- a/use_case_applications/content_creation.md
+++ b/use_case_applications/content_creation.md
@@ -1,0 +1,12 @@
+### Content Creation
+
+**Recommended Techniques:** Role-based prompting combined with few-shot examples.
+
+**Example Prompt:**
+```
+As an experienced financial journalist for The Economist, write an article analyzing the recent central bank interest rate decision.
+```
+
+**Tips:**
+- Include style guidelines or reference articles when possible.
+- Specify length or format requirements (e.g., 800 words, two-column layout).

--- a/use_case_applications/decision_support.md
+++ b/use_case_applications/decision_support.md
@@ -1,0 +1,9 @@
+### Decision Support
+
+**Recommended Techniques:** Tree-of-Thought plus Self-consistent prompting to analyze complex decisions from multiple perspectives.
+
+**Example Prompt:**
+```
+Should our company expand into the Southeast Asian market?
+Consider three different analytical frameworks: PESTEL, resource-based view, and scenario planning. For each, analyze the decision thoroughly, then synthesize into a final recommendation.
+```

--- a/use_case_applications/educational_explanations.md
+++ b/use_case_applications/educational_explanations.md
@@ -1,0 +1,8 @@
+### Educational Explanations
+
+**Recommended Techniques:** Analogy-based prompting combined with Chain-of-Thought.
+
+**Example Prompt:**
+```
+Explain how neural networks learn through backpropagation as if it were a team learning to play basketball. Step by step, describe the process, referring back to the analogy at each stage.
+```

--- a/use_case_applications/research_analysis.md
+++ b/use_case_applications/research_analysis.md
@@ -1,0 +1,9 @@
+### Research Analysis
+
+**Recommended Techniques:** Step-back prompting paired with Self-consistent approaches for reliable synthesis.
+
+**Example Prompt:**
+```
+Analyze the potential impact of quantum computing on current encryption standards.
+Before diving into specifics, step back and consider the fundamental principles and assumptions. Provide three independent analyses, then synthesize them into a final assessment noting areas of uncertainty.
+```


### PR DESCRIPTION
## Summary
- populate blank markdown files with prompting templates, examples, and tips
- add guides for zero-shot, few-shot, chain-of-thought, step-back prompting, self-consistency, ReAct and more
- document use case applications, advanced techniques, and implementation best practices

## Testing
- `git status --short`